### PR TITLE
Add private equity tag for Eurazeo resource

### DIFF
--- a/TEST
+++ b/TEST
@@ -879,6 +879,16 @@
                 description: "Guide pratique pour préparer et réussir ses stages professionnels.",
                 tags: ["stages", "guide", "préparation"]
             }
+                ,
+                {
+                    id: 9,
+                    title: "Eurazeo : Presentation des equipes buyout",
+                    type: "document",
+                    category: "partners",
+                    fileUrl: "https://drive.google.com/file/d/1CiStoLebcA4ktOX6iCXzWsx2VjBhiLLy/view?usp=sharing",
+                    description: "Document de presentation des equipes buyout d'Eurazeo, partenaire de la Fondation Florence.",
+                    tags: ["eurazeo", "partenariat", "buyout", "private equity"]
+                }
         ];
 
         // Données des fiches de révision (simulées)

--- a/index.html
+++ b/index.html
@@ -1001,6 +1001,16 @@ fileUrl: "https://example.com/documents/guide-stages.pdf",
 description: "Guide pratique pour préparer et réussir ses stages professionnels.",
 imageUrl: "https://fondationflorence.my.salesforce.com/sfc/p/07000000ZXDA/a/Jv000008oFvJ/ieYoVfuuZsg.NGcQU9yfI3DCNNXKO7ZbwJxIHc_NzxQ",
 tags: ["stages", "guide", "préparation"]
+},
+{
+id: 9,
+title: "Eurazéo : Présentation des équipes buyout",
+type: "document",
+category: "partners",
+fileUrl: "https://drive.google.com/file/d/1CiStoLebcA4ktOX6iCXzWsx2VjBhiLLy/view?usp=sharing",
+imageUrl: "https://www.eurazeo.com/sites/default/files/2025-01/eurazeovignette_0.JPG",
+description: "Document de présentation des équipes buyout d'Eurazéo, partenaire de la Fondation Florence.",
+tags: ["eurazeo", "partenariat", "buyout", "private equity"]
 }
 ];
 


### PR DESCRIPTION
## Summary
- extend Eurazeo buyout resource with a "private equity" tag in both the production and test datasets

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688904d39c288332aee01ac6b9dc727c